### PR TITLE
Add Vitest and tests for time utils

### DIFF
--- a/components/MorrisonsAldiMessagesGenerator.tsx
+++ b/components/MorrisonsAldiMessagesGenerator.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useState, useRef } from 'react';
 import * as XLSX from 'xlsx';
+import { subtractHour, timeToMinutes, minutesToTime } from './timeUtils';
 
 interface FuelPinData {
   [key: string]: {
@@ -241,22 +242,7 @@ export default function MorrisonsAldiMessagesGenerator() {
     }
   };
 
-  const subtractHour = (timeStr: string): string => {
-    const [hours, minutes] = timeStr.split(':').map(Number);
-    const newHours = hours - 1;
-    return `${String(newHours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
-  };
-
-  const timeToMinutes = (timeStr: string): number => {
-    const [hours, minutes] = timeStr.split(':').map(Number);
-    return hours * 60 + minutes;
-  };
-
-  const minutesToTime = (minutes: number): string => {
-    const hours = Math.floor(minutes / 60);
-    const mins = minutes % 60;
-    return `${String(hours).padStart(2, '0')}:${String(mins).padStart(2, '0')}`;
-  };
+  // time utility functions are imported from './timeUtils'
 
   const isSameDate = (date1: Date, date2: Date): boolean => {
     return date1.toDateString() === date2.toDateString();

--- a/components/__tests__/timeUtils.test.ts
+++ b/components/__tests__/timeUtils.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { subtractHour, timeToMinutes, minutesToTime } from '../timeUtils';
+
+describe('time utils', () => {
+  it("subtractHour wraps around midnight", () => {
+    expect(subtractHour('00:30')).toBe('23:30');
+  });
+
+  it('timeToMinutes converts correctly', () => {
+    expect(timeToMinutes('02:15')).toBe(135);
+  });
+
+  it('minutesToTime converts correctly', () => {
+    expect(minutesToTime(135)).toBe('02:15');
+  });
+});

--- a/components/timeUtils.ts
+++ b/components/timeUtils.ts
@@ -1,0 +1,16 @@
+export const subtractHour = (timeStr: string): string => {
+  const [hours, minutes] = timeStr.split(':').map(Number);
+  const newHours = (hours - 1 + 24) % 24;
+  return `${String(newHours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
+};
+
+export const timeToMinutes = (timeStr: string): number => {
+  const [hours, minutes] = timeStr.split(':').map(Number);
+  return hours * 60 + minutes;
+};
+
+export const minutesToTime = (minutes: number): string => {
+  const hours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  return `${String(hours).padStart(2, '0')}:${String(mins).padStart(2, '0')}`;
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest"
   },
   "dependencies": {
     "next": "15.3.3",
@@ -20,6 +21,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^1.0.0"
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Summary
- add Vitest setup and test script
- extract time utilities to `timeUtils.ts`
- fix `subtractHour` to wrap around midnight
- test `subtractHour`, `timeToMinutes`, and `minutesToTime`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d1ed303d483289b87849f2509c1dc